### PR TITLE
Chore/styling

### DIFF
--- a/src/components/hivedrop-dialog/hivedrop-dialog.tsx
+++ b/src/components/hivedrop-dialog/hivedrop-dialog.tsx
@@ -17,10 +17,6 @@ export default function HiveDropDialog({ props }: { props: HiveDropDialogProps }
  
     // toggles the dialog open or closed
     const { isHiveDropDialogOpen, setIsHiveDropDialogOpen } = useInspectionData();
-    // ensures the dialog starts off empty 
-    // const resetDialog = () => {
-    //     setHiveDropHiveGrades([]);
-    // };
     
     return (
         <div id="hivedrop-dialog-wrapper" className="absolute w-full z-5 flex gap-2 p-2 items-start">                                              
@@ -44,10 +40,10 @@ export default function HiveDropDialog({ props }: { props: HiveDropDialogProps }
                         </div>
                         <Separator />
                         <h4>Hives graded: {props.grades.length}</h4>
-                        <div className="max-h-[300px] overflow-y-scroll">
+                        <div className="max-h-[300px] overflow-y-scroll flex flex-col gap-6 border-1 border-border rounded-md p-5">
                             {props.grades.map((value, index) => (
-                                <div key={index} className="flex gap-2">
-                                    <p>Hive {index}</p>
+                                <div key={index} className="flex gap-6">
+                                    <p className="text-nowrap">Hive {index + 1}</p>
                                     <Slider     
                                     disabled
                                     defaultValue={[value]}
@@ -55,14 +51,18 @@ export default function HiveDropDialog({ props }: { props: HiveDropDialogProps }
                                     step={1}
                                     color="brand-light"
                                     />                                
+                                    <div className="text-nowrap text-lg font-bold text-brand-dark">{value}</div>
                                 </div>
                             ))}                        
-                        </div>                    
-                        <Separator />
-                        <Label htmlFor="notes">Notes</Label>
-                        <Textarea disabled id="notes" placeholder="Notes" value={props.notes}/>                        
+                        </div>                                            
+                        {props.notes && (
+                            <>                                
+                                <Label htmlFor="notes">Notes</Label>
+                                <Textarea disabled id="notes" placeholder="Notes" value={props.notes}/>                        
+                            </>
+                        )}
                         <DialogFooter>
-                            <Button variant="secondary" size="action" onClick={() => setIsHiveDropDialogOpen(false)}>Close</Button>
+                            <Button variant="customSecondary" size="action" onClick={() => setIsHiveDropDialogOpen(false)}>Close</Button>
                         </DialogFooter>
                 </DialogContent>            
             </Dialog>

--- a/src/components/inspection-controls/inspection-controls.tsx
+++ b/src/components/inspection-controls/inspection-controls.tsx
@@ -32,8 +32,7 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
         orchardHiveGrades, 
         setOrchardHiveGrades, 
         hiveDropHiveGrades, 
-        setHiveDropHiveGrades, 
-        hivesCounted, 
+        setHiveDropHiveGrades,         
         setHivesCounted, 
         hivesGraded,
         setHivesGraded,        
@@ -49,8 +48,9 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
     const [samplePercentage, setSamplePercentage] = useState<number>(0);    
     // toggles the dialog open or closed
     const [isOpen, setIsOpen] = useState(false);        
-    // updates the sample percentage whenever the user adds a new hive
-
+    // stores hivesCounted within the component until user hits "finish" -- then it updates context
+    const [hivesCountedLocal, setHivesCountedLocal] = useState<number[]>([]);
+    
     useEffect(() => {                
         if (orchardHiveGrades.length > 0) {                         
             const percentage = getSamplePercentage({ 
@@ -91,9 +91,9 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
                             New Hive-Drop
                         </DialogTitle>
                         <Progress 
-                            className="border-1 border-foreground-flexible-light"
-                            value={Math.min(hiveDropHiveGrades.length, hivesCounted[hiveDropIndex]*samplePercentage)}
-                            max={hivesCounted[hiveDropIndex]*samplePercentage}
+                            className="border-1 border-foreground-flexible-light"  
+                            value={Math.min(hiveDropHiveGrades.length, hivesCountedLocal[hiveDropIndex]*samplePercentage)}
+                            max={hivesCountedLocal[hiveDropIndex]*samplePercentage}
                         />
                     </DialogHeader>                
                     <Button variant="customSecondary"> Re-capture Location </Button>
@@ -104,9 +104,9 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
                                 id="count"                                 
                                 placeholder="number" 
                                 onChange={(event) => {
-                                    const newHivesCounted = [...hivesCounted];
-                                    newHivesCounted[hiveDropIndex] = Number(event.target.value);
-                                    setHivesCounted(newHivesCounted);                                                                   
+                                    const newHivesCountedLocal = [...hivesCountedLocal];
+                                    newHivesCountedLocal[hiveDropIndex] = Number(event.target.value);
+                                    setHivesCountedLocal(newHivesCountedLocal);                                                                   
                                 }}/>
                             <p className="text-sm text-muted-foreground">How many hives are there in this hive-drop?</p>
                         </div>
@@ -148,9 +148,10 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
                         <DialogFooter>
                             <Button variant="action" size="action" onClick={() => {                                                                                                      
                                 setIsOpen(false);                                                                   
+                                setHivesCounted(hivesCountedLocal);
                                 const newHivesGraded = [...hivesGraded, hiveDropHiveGrades.length];                                
-                                setHivesGraded(newHivesGraded);
-                                setAverage([...average, getHiveDropAverage(hiveDropHiveGrades)]);
+                                setHivesGraded(newHivesGraded);                                
+                                setAverage([...average, getHiveDropAverage(hiveDropHiveGrades)]);                                                                                    
                                 setApplyHiveDrop(applyHiveDrop + 1);
                                 setHiveDropIndex(hiveDropIndex + 1);
                                 setHiveDropHiveGrades([]);                                

--- a/src/components/inspection-controls/inspection-controls.tsx
+++ b/src/components/inspection-controls/inspection-controls.tsx
@@ -104,78 +104,80 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
                             New Hive-Drop
                         </DialogTitle>
                         <Progress 
-                            className="border-1 border-foreground-flexible-light"  
+                            className={clsx("border-1 border-foreground-flexible-light", CORNERS.CHILD)}   
                             value={Math.min(hiveDropHiveGrades.length, hivesCountedLocal[hiveDropIndex]*samplePercentage)}
                             max={hivesCountedLocal[hiveDropIndex]*samplePercentage}
                         />
                     </DialogHeader>                
                     <Button variant="customSecondary"> Re-capture Location </Button>
-                        <div className="grid w-full max-w-sm items-center gap-1.5">
-                            <Label htmlFor="count">Hives counted</Label>
-                            <Input 
-                                type="number" 
-                                id="count"                                 
-                                placeholder="number" 
-                                onChange={(event) => {
-                                    const newHivesCountedLocal = [...hivesCountedLocal];
-                                    newHivesCountedLocal[hiveDropIndex] = Number(event.target.value);
-                                    setHivesCountedLocal(newHivesCountedLocal);                                                                   
-                                }}/>
-                            <p className="text-sm text-muted-foreground">How many hives are there in this hive-drop?</p>
-                        </div>
-                        <Separator />
-                        <h4>Hives graded: {hiveDropHiveGrades.length}</h4>
-                        <div className="max-h-[300px] overflow-y-scroll">
-                            {hiveDropHiveGrades.map((value, index) => (
-                                <div key={index} className="flex gap-2">
-                                    <p>Hive {index}</p>
-                                    <Slider 
-                                    defaultValue={[value]}
-                                    max={24}
-                                    step={1}
-                                    color="brand-light"
-                                    onValueChange={(newValue) => {
-                                        const newHiveDropHiveGrades = [...hiveDropHiveGrades];
-                                        newHiveDropHiveGrades[index] = newValue[0];
-                                        setHiveDropHiveGrades(newHiveDropHiveGrades);    
-                                        const newOrchardHiveGrades = [...orchardHiveGrades];
-                                        newOrchardHiveGrades[hiveDropIndex] = hiveDropHiveGrades;
-                                        setOrchardHiveGrades(newOrchardHiveGrades);  
-                                        console.log("value: ", Math.min(hiveDropHiveGrades.length, hivesCountedLocal[hiveDropIndex]*samplePercentage));
-                                        console.log("max: ", hivesCountedLocal[hiveDropIndex]*samplePercentage)                                    
-                                    }}
-                                    />                                
-                                </div>
-                            ))}                        
-                            <Button variant="text" size="text" onClick={() => {  
-                                setHiveDropHiveGrades([...hiveDropHiveGrades, 12])                                
-                                const newOrchardHiveGrades = [...orchardHiveGrades];
-                                newOrchardHiveGrades[hiveDropIndex] = hiveDropHiveGrades;
-                                setOrchardHiveGrades(newOrchardHiveGrades);                                
-                            }}>Add hive +</Button>
-                        </div>                    
-                        <Separator />
-                        <Label htmlFor="notes">Notes</Label>
-                        <Textarea id="notes" placeholder="Notes" onChange={(event) => {
-                            setNotes(event.target.value);
-                        }}/>
-                        <Button variant="customSecondary" size="action">Add Photos</Button>
-                        <DialogFooter>
-                            <Button variant="action" size="action" onClick={() => {                                                                                                      
-                                // First update all the context data
-                                setHivesCounted(hivesCountedLocal);
-                                const newHivesGraded = [...hivesGraded, hiveDropHiveGrades.length];                                
-                                setHivesGraded(newHivesGraded);                                
-                                setAverage([...average, getHiveDropAverage(hiveDropHiveGrades)]);                                                                                    
-                                // Then trigger the save operation
-                                setApplyHiveDrop(applyHiveDrop + 1);
-                                // Update UI state
-                                setHiveDropIndex(hiveDropIndex + 1);
-                                setIsOpen(false);
-                                // Signal that form should be cleared after save
-                                setShouldClearForm(true);
-                            }}>Finish</Button>
-                        </DialogFooter>
+                    <div className="grid w-full max-w-sm items-center gap-1.5">
+                        <Label htmlFor="count">Hives counted</Label>
+                        <Input 
+                            type="number" 
+                            id="count"                                 
+                            placeholder="number" 
+                            onChange={(event) => {
+                                const newHivesCountedLocal = [...hivesCountedLocal];
+                                newHivesCountedLocal[hiveDropIndex] = Number(event.target.value);
+                                setHivesCountedLocal(newHivesCountedLocal);                                                                   
+                            }}/>
+                        <p className="text-sm text-muted-foreground">How many hives are there in this hive-drop?</p>
+                    </div>
+                    <Separator />
+                    <h4>Hives graded: {hiveDropHiveGrades.length}</h4>
+                    <div className="max-h-[300px] overflow-y-scroll flex flex-col gap-8 border-1 border-border rounded-md p-5">
+                        {hiveDropHiveGrades.map((value, index) => (
+                            <div key={index} className="flex gap-6">
+                                <p className="text-nowrap">Hive {index + 1}</p>
+                                <Slider 
+                                defaultValue={[value]}
+                                max={24}
+                                step={1}
+                                color="brand-light"
+                                onValueChange={(newValue) => {
+                                    const newHiveDropHiveGrades = [...hiveDropHiveGrades];
+                                    newHiveDropHiveGrades[index] = newValue[0];
+                                    setHiveDropHiveGrades(newHiveDropHiveGrades);    
+                                    const newOrchardHiveGrades = [...orchardHiveGrades];
+                                    newOrchardHiveGrades[hiveDropIndex] = hiveDropHiveGrades;
+                                    setOrchardHiveGrades(newOrchardHiveGrades);  
+                                    console.log("value: ", Math.min(hiveDropHiveGrades.length, hivesCountedLocal[hiveDropIndex]*samplePercentage));
+                                    console.log("max: ", hivesCountedLocal[hiveDropIndex]*samplePercentage)                                    
+                                }}
+                                />     
+                                <div className="text-nowrap text-lg font-bold text-brand-dark">{value}</div>                           
+                            </div>
+                        ))}                          
+                        <Button variant="action" size="action" onClick={() => {  
+                            setHiveDropHiveGrades([...hiveDropHiveGrades, 12])                                
+                            const newOrchardHiveGrades = [...orchardHiveGrades];
+                            newOrchardHiveGrades[hiveDropIndex] = hiveDropHiveGrades;
+                            setOrchardHiveGrades(newOrchardHiveGrades);                                
+                        }}>Add hive +</Button>
+                        </div>                                                                                                                
+                    <Label htmlFor="notes">Notes</Label>
+                    <Textarea id="notes" placeholder="Notes" onChange={(event) => {
+                        setNotes(event.target.value);
+                    }}/>
+                    <div className="w-full">
+                        <Button variant="ghost" size="left">Add Photos +</Button>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="customSecondary" size="action" onClick={() => {                                                                                                      
+                            // First update all the context data
+                            setHivesCounted(hivesCountedLocal);
+                            const newHivesGraded = [...hivesGraded, hiveDropHiveGrades.length];                                
+                            setHivesGraded(newHivesGraded);                                
+                            setAverage([...average, getHiveDropAverage(hiveDropHiveGrades)]);                                                                                    
+                            // Then trigger the save operation
+                            setApplyHiveDrop(applyHiveDrop + 1);
+                            // Update UI state
+                            setHiveDropIndex(hiveDropIndex + 1);
+                            setIsOpen(false);
+                            // Signal that form should be cleared after save
+                            setShouldClearForm(true);
+                        }}>Finish</Button>
+                    </DialogFooter>
                 </DialogContent>            
             </Dialog>
         </div>

--- a/src/components/inspection-controls/inspection-controls.tsx
+++ b/src/components/inspection-controls/inspection-controls.tsx
@@ -52,14 +52,17 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
     const [hivesCountedLocal, setHivesCountedLocal] = useState<number[]>([]);
     
     useEffect(() => {                
-        if (orchardHiveGrades.length > 0) {                         
+        const totalGradedHives = orchardHiveGrades.flat().length;
+        if (totalGradedHives > 1) {                         
             const percentage = getSamplePercentage({ 
                 populationSize: totalHivesContracted, 
                 totalHiveGrades: orchardHiveGrades
             });
             setSamplePercentage(percentage);                   
+        } else {
+            setSamplePercentage(0.1);
         }
-    }, [orchardHiveGrades]);
+    }, [orchardHiveGrades, totalHivesContracted]);
 
     return (
         <div id="inspection-controls-wrapper" className={clsx("absolute right-0 w-full md:w-[calc(100vw-440px)] z-5 flex gap-2 p-2 items-stretch pointer-events-none", isShown ? "block" : "hidden")}>             
@@ -128,6 +131,8 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
                                         const newOrchardHiveGrades = [...orchardHiveGrades];
                                         newOrchardHiveGrades[hiveDropIndex] = hiveDropHiveGrades;
                                         setOrchardHiveGrades(newOrchardHiveGrades);  
+                                        console.log("value: ", Math.min(hiveDropHiveGrades.length, hivesCountedLocal[hiveDropIndex]*samplePercentage));
+                                        console.log("max: ", hivesCountedLocal[hiveDropIndex]*samplePercentage)                                    
                                     }}
                                     />                                
                                 </div>

--- a/src/components/inspection-controls/inspection-controls.tsx
+++ b/src/components/inspection-controls/inspection-controls.tsx
@@ -50,10 +50,12 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
     const [isOpen, setIsOpen] = useState(false);        
     // stores hivesCounted within the component until user hits "finish" -- then it updates context
     const [hivesCountedLocal, setHivesCountedLocal] = useState<number[]>([]);
+    // track when to clear form data
+    const [shouldClearForm, setShouldClearForm] = useState(false);
     
     useEffect(() => {                
         const totalGradedHives = orchardHiveGrades.flat().length;
-        if (totalGradedHives > 1) {                         
+        if (totalGradedHives > 2) {                         
             const percentage = getSamplePercentage({ 
                 populationSize: totalHivesContracted, 
                 totalHiveGrades: orchardHiveGrades
@@ -63,6 +65,14 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
             setSamplePercentage(0.1);
         }
     }, [orchardHiveGrades, totalHivesContracted]);
+
+    // Clear form data after save is complete
+    useEffect(() => {
+        if (shouldClearForm) {
+            setHiveDropHiveGrades([]);
+            setShouldClearForm(false);
+        }
+    }, [shouldClearForm]);
 
     return (
         <div id="inspection-controls-wrapper" className={clsx("absolute right-0 w-full md:w-[calc(100vw-440px)] z-5 flex gap-2 p-2 items-stretch pointer-events-none", isShown ? "block" : "hidden")}>             
@@ -152,14 +162,18 @@ export default function InspectionControls({ totalHivesContracted }: InspectionC
                         <Button variant="customSecondary" size="action">Add Photos</Button>
                         <DialogFooter>
                             <Button variant="action" size="action" onClick={() => {                                                                                                      
-                                setIsOpen(false);                                                                   
+                                // First update all the context data
                                 setHivesCounted(hivesCountedLocal);
                                 const newHivesGraded = [...hivesGraded, hiveDropHiveGrades.length];                                
                                 setHivesGraded(newHivesGraded);                                
                                 setAverage([...average, getHiveDropAverage(hiveDropHiveGrades)]);                                                                                    
+                                // Then trigger the save operation
                                 setApplyHiveDrop(applyHiveDrop + 1);
+                                // Update UI state
                                 setHiveDropIndex(hiveDropIndex + 1);
-                                setHiveDropHiveGrades([]);                                
+                                setIsOpen(false);
+                                // Signal that form should be cleared after save
+                                setShouldClearForm(true);
                             }}>Finish</Button>
                         </DialogFooter>
                 </DialogContent>            

--- a/src/components/map/add-hivedrop.ts
+++ b/src/components/map/add-hivedrop.ts
@@ -23,9 +23,9 @@ export const addHiveDrop = (
     },
     attributes: {
       [HIVEDROP_FIELD_NAMES.OBJECT_ID]: hiveDropIndex,
-      [HIVEDROP_FIELD_NAMES.HIVES_COUNTED]: hivesCounted[hiveDropIndex -1], 
-      [HIVEDROP_FIELD_NAMES.AVERAGE]: average[hiveDropIndex -1],
-      [HIVEDROP_FIELD_NAMES.HIVES_GRADED]: hivesGraded[hiveDropIndex -1],
+      [HIVEDROP_FIELD_NAMES.HIVES_COUNTED]: hivesCounted[hiveDropIndex - 1], 
+      [HIVEDROP_FIELD_NAMES.AVERAGE]: average[hiveDropIndex - 1],
+      [HIVEDROP_FIELD_NAMES.HIVES_GRADED]: hivesGraded[hiveDropIndex - 1],
       ...HIVEDROP_FIELD_NAMES.GRADES.reduce((acc, grade, index) => ({
         ...acc,
         [grade]: hiveDropHiveGrades[index]

--- a/src/components/map/add-hivedrop.ts
+++ b/src/components/map/add-hivedrop.ts
@@ -10,10 +10,10 @@ export const addHiveDrop = (
   hiveDropHiveGrades: number[],
   notes: string,
   recordId: string,
-  userLocation: number[]
-) => {  
-
-  console.log("hiveDropHiveGrades from add-hivedrop", hiveDropHiveGrades)
+  userLocation: number[],
+  average: number[],
+  hivesGraded: number[]
+) => {    
  
   const newHiveDrop = new Graphic({
     geometry: {
@@ -23,7 +23,9 @@ export const addHiveDrop = (
     },
     attributes: {
       [HIVEDROP_FIELD_NAMES.OBJECT_ID]: hiveDropIndex,
-      [HIVEDROP_FIELD_NAMES.HIVES_COUNTED]: hivesCounted[hiveDropIndex -1],
+      [HIVEDROP_FIELD_NAMES.HIVES_COUNTED]: hivesCounted[hiveDropIndex -1], 
+      [HIVEDROP_FIELD_NAMES.AVERAGE]: average[hiveDropIndex -1],
+      [HIVEDROP_FIELD_NAMES.HIVES_GRADED]: hivesGraded[hiveDropIndex -1],
       ...HIVEDROP_FIELD_NAMES.GRADES.reduce((acc, grade, index) => ({
         ...acc,
         [grade]: hiveDropHiveGrades[index]

--- a/src/components/map/map-handlers.ts
+++ b/src/components/map/map-handlers.ts
@@ -134,9 +134,11 @@ export const handleDeselection = (
   orchardLayer: FeatureLayer,
   hiveDropsLayer: FeatureLayer,
   perimitersLayer: FeatureLayer,
-  setIsMobileSheetOpen: (open: boolean) => void
+  setIsMobileSheetOpen: (open: boolean) => void,
+  setIsShown: (shown: boolean) => void
 ) => {
   setIsMobileSheetOpen(false);
+  setIsShown(false);
   // Return map to showing all orchards
   orchardLayer.visible = true;
   hiveDropsLayer.visible = false;

--- a/src/components/map/web-map.tsx
+++ b/src/components/map/web-map.tsx
@@ -47,7 +47,8 @@ export default function Map() {
     userLocation,
     hivesCounted,
     average,
-    hivesGraded
+    hivesGraded,
+    setIsShown
   } = useInspectionData();
 
   // State for mobile sheet
@@ -70,8 +71,8 @@ export default function Map() {
 
     // Create map with all layers
     const map = new ArcGISMap({
-      basemap: "arcgis/imagery",
-      layers: [perimitersLayer, orchardLayer, hiveDropsLayer]
+      layers: [perimitersLayer, orchardLayer, hiveDropsLayer],
+      basemap: "arcgis/imagery"      
     });
 
     // Create map view
@@ -82,12 +83,15 @@ export default function Map() {
       zoom: MAP_CONFIG.DEFAULT_ZOOM,
     });
 
+    view.ui.move("zoom", "bottom-right");
+
     // Add GPS tracking widget
     const track = new Track({
       view: view
     });
-    view.ui.add(track, "top-right");
-    track.start();
+    view.ui.add(track, "bottom-right");
+
+    track.start();    
 
     // Listen for location updates
     track.on("track", (event) => {
@@ -161,7 +165,8 @@ export default function Map() {
           orchardLayer,
           hiveDropsLayer,
           perimitersLayer,
-          setIsMobileSheetOpen
+          setIsMobileSheetOpen,
+          setIsShown
         );
       }
     });
@@ -189,7 +194,7 @@ export default function Map() {
         hivesGraded
       );
     }
-  }, [applyHiveDrop]);
+  }, [applyHiveDrop]);  
 
   return (
     <div>

--- a/src/components/map/web-map.tsx
+++ b/src/components/map/web-map.tsx
@@ -175,7 +175,6 @@ export default function Map() {
   }, []);
 
   // Create function for adding hive drop features
-
   useEffect(() => {    
     if (applyHiveDrop > 0 && hiveDropsLayerRef.current) {
       addHiveDrop(
@@ -190,7 +189,7 @@ export default function Map() {
         hivesGraded
       );
     }
-  }, [applyHiveDrop]);  
+  }, [applyHiveDrop]);
 
   return (
     <div>

--- a/src/components/map/web-map.tsx
+++ b/src/components/map/web-map.tsx
@@ -45,7 +45,9 @@ export default function Map() {
     notes,
     recordId,
     userLocation,
-    hivesCounted
+    hivesCounted,
+    average,
+    hivesGraded
   } = useInspectionData();
 
   // State for mobile sheet
@@ -183,7 +185,9 @@ export default function Map() {
         hiveDropHiveGrades,
         notes,
         recordId,
-        userLocation
+        userLocation,
+        average,
+        hivesGraded
       );
     }
   }, [applyHiveDrop]);  

--- a/src/components/mobile-sheet/inspection-section.tsx
+++ b/src/components/mobile-sheet/inspection-section.tsx
@@ -22,7 +22,7 @@ interface InspectionSectionProps {
 export default function InspectionSection({ toggleOpen }: InspectionSectionProps) {
 
   // data from context used to fill out the hivedrops list
-  const { setIsShown, hivesCounted, hivesGraded, average } = useInspectionData();
+  const { setIsShown, hivesCounted, hivesGraded, average, isShown } = useInspectionData();
 
   // used to display the average as a badge with the correct variant
   const getBadgeVariant = (average: number): "pass" | "fail" | "low" | "outline" => {
@@ -43,15 +43,16 @@ export default function InspectionSection({ toggleOpen }: InspectionSectionProps
         </Label>
         <Button 
           id="begin-inspection" 
-          variant="action" 
+          variant={isShown ? "customSecondary" : "action"} 
           size="action" 
           onClick={() => (
-            setIsShown(true),
+            setIsShown(!isShown),
             toggleOpen()
           )}
         >
-        Begin Inspection
+          {isShown ? "End Inspection" : "New Inspection"}
         </Button>
+        {hivesCounted.length > 0 && (
         <Table>
           <TableHeader>
             <TableRow>              
@@ -59,7 +60,7 @@ export default function InspectionSection({ toggleOpen }: InspectionSectionProps
               <TableHead>Hives Graded</TableHead>
               <TableHead>Average</TableHead>
             </TableRow>
-          </TableHeader>
+          </TableHeader>            
           <TableBody>            
               {hivesCounted.map((count, index) => {
                 return (
@@ -75,9 +76,10 @@ export default function InspectionSection({ toggleOpen }: InspectionSectionProps
                     </TableCell>
                   </TableRow>
                 )
-              })}            
+              })}    
           </TableBody>
-        </Table>
+        </Table>              
+        )}                  
       </div>
     </>
   );

--- a/src/components/mobile-sheet/mobile-sheet.tsx
+++ b/src/components/mobile-sheet/mobile-sheet.tsx
@@ -23,7 +23,13 @@ import { MobileSheetProps } from "../types";
 // Constants
 import { SHEET, STATUS_CONFIG } from "@/constants";
 
+// Context
+import { useInspectionData } from "@/context/inspectionData"
+
 export default function MobileSheet({ props }: { props: MobileSheetProps }) {
+
+  const { setIsShown } = useInspectionData();
+
   const sheetRef = useRef<HTMLDivElement>(null);
 
   // Use custom hooks to manage complex logic
@@ -84,7 +90,7 @@ export default function MobileSheet({ props }: { props: MobileSheetProps }) {
         {/* Main content body */}
         <div 
           id="body" 
-          className="px-2 pt-6 flex flex-col gap-6 items-center h-full overflow-scroll bg-background-secondary border-x-1 border-border"
+          className="p-2 flex flex-col gap-6 items-center h-full overflow-scroll bg-background-secondary border-x-1 border-border"
         >
           <Accordion type="single" collapsible defaultValue="item-4">
             {/* Hive Contract Information */}
@@ -126,9 +132,11 @@ export default function MobileSheet({ props }: { props: MobileSheetProps }) {
           {/* Submit button */}
           <Button 
             variant="customSecondary" 
-            size="action" 
-            onClick={() => props.onMarkComplete(formData)}
-          >
+            size="lg" 
+            onClick={() => {
+              props.onMarkComplete(formData);
+              setIsShown(false);
+            }}>
             Mark Complete
           </Button>
         </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
         action:
           "bg-brand-light border-1 border-foreground-flexible-light text-foreground-flexible font-bold tracking-wide shadow-lg shadow-brand-light/60 hover:bg-brand-light/60",
         customSecondary:
-          "text-foreground-flexible font-semibold tracking-wide bg-foreground-flexible/10 hover:bg-foreground-flexible/30",
+          "border-1 border-foreground-flexible-light text-foreground-flexible font-semibold tracking-wide bg-foreground-flexible/10 hover:bg-foreground-flexible/30",
         text:
           "hover:text-accent-foreground dark:hover:bg-accent/50 items-start",
         map:
@@ -35,10 +35,11 @@ const buttonVariants = cva(
         default: "h-9 px-4 py-2 has-[>svg]:px-3 text-sm rounded-md",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 text-sm",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4 text-sm",
-        action: "rounded-md py-3 px-6 text-sm",
+        action: "rounded-md py-3 px-6 text-sm w-full",
         icon: "size-9 text-sm rounded-md",
         text: "pl-0 text-sm rounded-md",
-        map: `h-full text-lg rounded-xl px-6 ${CORNERS.CHILD}`
+        map: `h-full text-lg rounded-xl px-6 ${CORNERS.CHILD}`,
+        left: "h-9 px-0 py-2 has-[>svg]:px-0 text-sm rounded-md"        
       },
     },
     defaultVariants: {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -87,7 +87,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        "flex flex-col-reverse gap-2",
         className
       )}
       {...props}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -37,13 +37,13 @@ function Slider({
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          "bg-brand-light/30 relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
         )}
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            "bg-brand-dark absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
           )}
         />
       </SliderPrimitive.Track>
@@ -51,7 +51,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="border-brand-dark bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>

--- a/src/index.css
+++ b/src/index.css
@@ -15,8 +15,7 @@ html, body, #root {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --color-foreground: var(--foreground);
+  --radius-xl: calc(var(--radius) + 4px);  
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);
@@ -49,6 +48,7 @@ html, body, #root {
   /* customized vars */
   --color-background: var(--background);
   --color-secondary: var(--secondary);
+  --color-foreground: oklch(0.3212 0.0109 168.01);
   
   /* custom vars */
   --color-background-secondary: oklch(0.97 0.0025 165.08);
@@ -99,6 +99,7 @@ html, body, #root {
   --background: oklch(0.99 0.0066 286.28);
   --border: oklch(0.89 0 0);
   --sidebar-width: 440px;
+  --color-foreground-custom: oklch(0.3212 0.0109 168.01);
 }
 
 .dark {


### PR DESCRIPTION
## Layout and spacing
- Made the spacing consistent in the two dialog components
- Adjusted layout to let inspection controls and arcGIS map widgets coexist.
## Color
- Infused more of the brand color
- Changed pure black to muted black
## Misc
- Added more conditional rendering of components. For example, the notes component in hivedrop dialog is now not rendered when there is no notes string provided.
- I threw in some quick bug fixes regarding the progress bar and applyEdits()
## To do
- Animate entry/exit of sheet (for tablet/desktop) and inspection controls
- Make tailwind more efficient/clean